### PR TITLE
Commands interface changed to reflect redis.v4 types

### DIFF
--- a/options.go
+++ b/options.go
@@ -13,7 +13,7 @@ type Options struct {
 	Addrs []string
 
 	// DB only applies to single-node clients
-	DB int64
+	DB int
 
 	// MasterName only accepted for sentinel backed clients
 	MasterName string


### PR DESCRIPTION
WARNING - breaking changes, major version bump required (package builds, but is incompatible with prev version, that used `redis.v3`).

TODOs/requests for future:

Also, right now `Command`/`Client` are missing following methods:

For `redis.Client`:

```
    ClientGetName() *redis.StringCmd

    PSubscribe(channels ...string) (*redis.PubSub, error)
    PubSub() *redis.PubSub
    Publish(channel, message string) *redis.IntCmd
    String() string
    Subscribe(channels ...string) (*redis.PubSub, error)
```

For `redis.ClusterClient`:

```
ForEachMaster(fn func(client *Client) error) error
```

These methods may have dummy implementations (with `panic(...)`?) for `clusterClient` and `simpleClient`, but that's risky (may work on developer's machine and panic with redis cluster).

Also, new `redis.Tx` type was introduced (ex-`redis.Multi`). Probably, it should be also interfaced here.
